### PR TITLE
Enhancements to ontology schema DSL

### DIFF
--- a/src/arachne/core/config/ontology.clj
+++ b/src/arachne/core/config/ontology.clj
@@ -48,12 +48,15 @@
 (defn class
   "Build a class definition map, returning a seq of txdata."
   [ident supers docstring & attrs]
+  (apply util/validate-args `class ident supers docstring attrs)
   (let [update-domain (fn [attr-map] (update attr-map :arachne.attribute/domain
                                        (fnil conj #{}) (by-ident ident)))
         class-map {:db/id (cfg/tempid)
                    :db/ident ident
                    :db/doc docstring}
         class-map (if (not-empty supers)
-                    (assoc class-map :arachne.class/superclasses supers)
+                    (assoc class-map :arachne.class/superclasses
+                                     (map (fn [super]
+                                            {:db/ident super}) supers))
                     class-map)]
     (cons class-map (map update-domain attrs))))

--- a/src/arachne/core/config/ontology/specs.clj
+++ b/src/arachne/core/config/ontology/specs.clj
@@ -53,6 +53,15 @@
                                  :cardinality-range ::cardinality-range)))
   :ret ::config-spec/map-txform)
 
+(s/def ::class-ident (s/and keyword? namespace))
+
+(s/fdef arachne.core.config.ontology/class
+  :args (s/cat :ident ::class-ident
+               :supers (s/coll-of ::class-ident)
+               :docstring string?
+               :attrs (s/* ::config-spec/map-txform))
+  :ret ::config-spec/list-txform)
+
 (comment
 
   (s/conform ::cardinality-range [1 2])


### PR DESCRIPTION
- Add specs for `class` function
- Fix issue with specifying superclasses that are defined in the same
  transaction.