### PR TITLE
fixes and enhancements discovered while working on Pedestal module

### DIFF
--- a/src/arachne/core.clj
+++ b/src/arachne/core.clj
@@ -7,6 +7,24 @@
             [arachne.core.schema :as schema]
             [arachne.core.specs]))
 
+(defn instance-ctor
+  "Component constructor that defines components by resolving a var"
+  [component]
+  @(util/require-and-resolve (:arachne.component/instance component)))
+
+(defn- add-instance-constructors
+  "Implement :arachne.component/instance in terms of :arachne.component/constructor"
+  [cfg]
+  (let [components (cfg/q cfg '[:find [?c ...]
+                                :where
+                                [?c :arachne.component/instance ?var]])]
+    (if (empty? components)
+      cfg
+      (cfg/update cfg
+        (for [c components]
+          {:db/id c
+           :arachne.component/constructor :arachne.core/instance-ctor})))))
+
 (defn schema
   "Return the schema for the core module"
   []
@@ -15,7 +33,7 @@
 (defn configure
   "Configure the core module"
   [cfg]
-  cfg)
+  (add-instance-constructors cfg))
 
 (defn build-config
   "Construct a configuration, using the specified namespace. The specified modules will participate in the configuration after initializing it with the given user-supplied initializer value.
@@ -29,5 +47,5 @@
   (util/validate-args `build-config config-ns root-modules initializer)
   (let [modules (m/load root-modules)
         cfg (init/initialize config-ns modules initializer)
-        cfg (reduce (fn [c m] (m/configure m c)) cfg modules)]
+        cfg (reduce (fn [c m] (m/configure m c)) cfg (reverse modules))]
     cfg))

--- a/src/arachne/core/config.clj
+++ b/src/arachne/core/config.clj
@@ -143,3 +143,14 @@
   `arachne/tempid []` or `arachne/tempid [-1]`"
   [form]
   (apply tempid form))
+
+(defn attr
+  "Convenience function to pull and return one or more nested attributes in one
+  step"
+  [cfg id & attrs]
+  (let [[attr & more-attrs] (reverse attrs)
+        expr (reduce (fn [inner attr]
+                       {attr inner})
+               [attr] more-attrs)
+        result (pull cfg (if (map? expr) [expr] expr) id)]
+    (get-in result attrs)))

--- a/src/arachne/core/schema.clj
+++ b/src/arachne/core/schema.clj
@@ -16,14 +16,20 @@
         :many :arachne.component/Dependency
         "The dependencies of a component.")
       (o/attr :arachne.component/constructor :one :keyword
-        "Namespaced keyword indicating the fully-qualified name of a function that returns an uninitialized instance of a component. The function must take two arguments; the configuration, and the entity ID of the component definition to instantiate."))
+        "Namespaced keyword indicating the fully-qualified name of a function that returns an uninitialized instance of a component. The function may take 0-2 arguments, with the following behaviors:
+
+         - 0 arguments: invoked with no arguments
+         - 1 argument:  the entity map obtained by a wildcard pull on the component entity
+         - 2 argumetns: the config itself and entity ID of the component entity")
+      (o/attr :arachne.component/instance :one-or-none :keyword
+        "Namespaced keyword indicating the fully-qualified name of a var which is the initial instance of the component."))
 
     (o/class :arachne.component/Dependency []
       "Entity describing the link from a component a dependent component"
       (o/attr :arachne.component.dependency/entity :one :arachne/Component
         "Links a component dependency to another component entity.")
-      (o/attr :arachne.component.dependency/key :one :keyword
-        "The key with which to inject a dependency."))
+      (o/attr :arachne.component.dependency/key :one-or-none :keyword
+        "The key with which to inject a dependency. If omitted, the key will default to the keyword-ified entity ID of the dependency."))
 
     (o/class :arachne/Runtime []
       "Entity describing a particular Arachne runtime"
@@ -38,5 +44,6 @@
         part of this configuration.")
       (o/attr :arachne.configuration/roots :one-or-more :arachne/Entity
         "Reference to the top-level entities that are part of this configuration."))
+
 
     ))

--- a/src/arachne/core/util.clj
+++ b/src/arachne/core/util.clj
@@ -98,9 +98,11 @@
        (instance? class# obj#))))
 
 (defn mkeep
-  "Returns the given map, with all entries with nil values removed"
+  "Returns the given map, with all entries with nil or empty values removed"
   [m]
-  (into {} (filter (fn [[_ v]] (not (nil? v))) m)))
+  (into {} (filter (fn [[_ v]]
+                     (not (or (nil? v)
+                            (and (coll? v) (empty? v))))) m)))
 
 (deferror ::arity-detection-error "Could not detect the arity of :f, perhaps it is not a function?")
 

--- a/test/arachne/core/runtime_test.clj
+++ b/test/arachne/core/runtime_test.clj
@@ -3,7 +3,8 @@
             [arachne.core :as core]
             [arachne.core.config :as cfg]
             [arachne.core.runtime :as rt]
-            [com.stuartsierra.component :as component]))
+            [com.stuartsierra.component :as component]
+            [arachne.core.util :as util]))
 
 (def basic-config
   [{:db/id (cfg/tempid)
@@ -161,7 +162,12 @@
     (let [started-rt (component/start rt)
           instances (into {} (:system started-rt))]
       (is (-> root-eid (instances) :dep-1 :dep-2 :dep-3 :this-is-dep-3))
-      (is (-> root-eid (instances) :dep-2 :dep-3 :this-is-dep-3)))))
+      (is (-> root-eid (instances) :dep-2 :dep-3 :this-is-dep-3))
+      (testing "dep-instance utility function"
+        (is (= (instances d1-eid)
+              (rt/dependency-instance (instances root-eid) cfg d1-eid)))
+        (is (= (instances d3-eid)
+              (rt/dependency-instance (instances d2-eid) cfg d3-eid)))))))
 
 
 (def ^:dynamic *tracker* nil)
@@ -192,8 +198,7 @@
       :arachne.component/constructor
       :arachne.core.runtime-test/construct-lifecycle,
       :arachne.component/dependencies
-      #{{:arachne.component.dependency/key :b
-         :arachne.component.dependency/entity b}}},
+      #{{:arachne.component.dependency/entity b}}},
      {:db/id b
       :arachne/id :test/b
       :arachne.component/constructor


### PR DESCRIPTION
- fix issue with constructor arity detection

- add utility function to retrieve entity attributes

- add var-based component constructor

- modules ought to have been configured in reverse dependency order

- mkeep now filters out empty collection values

- allow eids as default dependency keys

- add new helper function to find dependency instances