### PR TITLE
fix typo in doc string

### DIFF
--- a/src/arachne/core/config/init.clj
+++ b/src/arachne/core/config/init.clj
@@ -60,7 +60,7 @@
       (f))))
 
 (defmacro defdsl
-  "Convenience marco to define a DSL function that tracks provenance
+  "Convenience macro to define a DSL function that tracks provenance
    metadata, and validates its arguments according to the registered spec"
   [name docstr argvec & body]
   (let [fqn (symbol (str (ns-name *ns*)) (str name))]


### PR DESCRIPTION
I'm sure Marco is a very convenient guy, but I think this should be a macro instead.